### PR TITLE
Updating package references for RestSharp and Microsoft Playwright.

### DIFF
--- a/PlaywrightExtra.cs
+++ b/PlaywrightExtra.cs
@@ -302,7 +302,8 @@ public class PlaywrightExtra : IBrowser, IDisposable
 
     public async void Dispose()
     {
-        await _browser.DisposeAsync();
+        if(_browser is not null)
+            await _browser.DisposeAsync();
         _playwright?.Dispose();
     }
 

--- a/PlaywrightExtra.cs
+++ b/PlaywrightExtra.cs
@@ -271,8 +271,12 @@ public class PlaywrightExtra : IBrowser, IDisposable
     {
         if(_browser is not null)
             await _browser.CloseAsync();
-        if(_browserContext is not null)
-            await _browserContext.CloseAsync();
+    }
+
+    public async Task CloseAsync(BrowserCloseOptions? options = null)
+    {
+        if (_browser is not null)
+            await _browser.CloseAsync(options);
     }
 
     public Task<ICDPSession> NewBrowserCDPSessionAsync()

--- a/PlaywrightExtraSharp.csproj
+++ b/PlaywrightExtraSharp.csproj
@@ -17,8 +17,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Playwright" Version="1.39.0" />
-        <PackageReference Include="RestSharp" Version="110.2.0" />
+        <PackageReference Include="Microsoft.Playwright" Version="1.49.0" />
+        <PackageReference Include="RestSharp" Version="112.1.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
**Overview** 

Updates to support latest version of Microsoft.Playwright and adding null check to dispose

**Changes**

- Implementing IBrowser.CloseAsync(BrowserCloseOptions) method
- Updating existing IBrowser.CloseAsync() method to no longer explicitly close the browser context. Exception was being thrown with new Playwright version due to the browser already being closed. 
- Updating RestSharp package version to latest. 
- Added missing null check on browser in Dispose call.

Fixes #6 
Fixes #7 